### PR TITLE
Move qt script into the Windows specific pkg.

### DIFF
--- a/msft_ros_env/CMakeLists.txt
+++ b/msft_ros_env/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(msft_ros_env)
+find_package(catkin REQUIRED)
+
+catkin_package()
+
+set(ROS_VERSION "1")
+
+# allow overriding the Python version
+if(DEFINED ENV{ROS_PYTHON_VERSION})
+  set(ROS_PYTHON_VERSION "$ENV{ROS_PYTHON_VERSION}")
+else()
+  set(ROS_PYTHON_VERSION "2")
+endif()
+
+# allow overriding the distro name
+if(DEFINED ENV{ROS_DISTRO_OVERRIDE})
+  set(ROS_DISTRO $ENV{ROS_DISTRO_OVERRIDE})
+else()
+  set(ROS_DISTRO "melodic")
+endif()
+
+set(
+  hooks
+  "msft_ros_qt"
+)
+if(CMAKE_HOST_UNIX)
+  set(shell "sh")
+else()
+  set(shell "bat")
+endif()
+foreach(hook ${hooks})
+  catkin_add_env_hooks("${hook}" SHELLS ${shell} DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/env-hooks)
+endforeach()

--- a/msft_ros_env/LICENSE
+++ b/msft_ros_env/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/msft_ros_env/env-hooks/msft_ros_qt.bat.in
+++ b/msft_ros_env/env-hooks/msft_ros_qt.bat.in
@@ -1,0 +1,34 @@
+REM generated from msft_ros_env/env-hooks/msft_ros_qt.bat.in
+setlocal
+
+set qt5dir=
+for /f "tokens=* USEBACKQ" %%f in (`where qt5core.dll 2^>NUL`) do (
+    set qt5dir=%%f
+    goto :break
+)
+:break
+
+if not defined qt5dir (
+    goto :eof
+)
+
+set basedir=
+CALL :getbasedir %qt5dir%
+
+set abspath=
+CALL :getabspath %basedir%..\plugins
+
+if not exist %abspath% (
+    goto :eof
+)
+
+endlocal && set QT_PLUGIN_PATH=%abspath%
+goto :eof
+
+:getbasedir
+set basedir=%~dp1
+goto :eof
+
+:getabspath
+set abspath=%~f1
+goto :eof

--- a/msft_ros_env/env-hooks/msft_ros_qt.sh.in
+++ b/msft_ros_env/env-hooks/msft_ros_qt.sh.in
@@ -1,0 +1,1 @@
+REM generated from msft_ros_env/env-hooks/msft_ros_qt.sh.in

--- a/msft_ros_env/package.xml
+++ b/msft_ros_env/package.xml
@@ -1,0 +1,9 @@
+<package>
+  <name>msft_ros_env</name>
+  <version>0.0.1</version>
+  <description>The package adds additonal environment variables for ROS on Windows.</description>
+  <maintainer email="seanyen@microsoft.com">Sean Yen</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+</package>

--- a/msft_ros_pkgs/package.xml
+++ b/msft_ros_pkgs/package.xml
@@ -8,6 +8,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <exec_depend>msft_ros_vcpkg</exec_depend>
+  <exec_depend>msft_ros_env</exec_depend>
 
   <export>
     <metapackage/>


### PR DESCRIPTION
I am moving the QT discovery scripts, which is very specific to our Windows installation, from `ros_environment` into `msft_ros_pkgs` meta-package (for this [script](https://github.com/ms-iot/ros_environment/blob/init_windows/env-hooks/1.ros_misc.bat.in)). After the move, I am going to send another pull request to update our buildfarm to use the upstream version of `ros_environment`.