### PR TITLE
Add vcpkg bin path for dll resolution

### DIFF
--- a/msft_ros_vcpkg/env-hooks/msft_ros_vcpkg.bat.in
+++ b/msft_ros_vcpkg/env-hooks/msft_ros_vcpkg.bat.in
@@ -3,5 +3,5 @@ REM generated from rosonwindows_vcpkg/env-hooks/rosonwindows_vcpkg.bat.in
 set "CMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH:;C:/opt/vcpkg/installed/x64-windows=%"
 set "CMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH%;C:/opt/vcpkg/installed/x64-windows"
 set "VCPKG_ROOT=c:\opt\vcpkg"
-set "PATH=%PATH:c:\opt\vcpkg;=%"
-set "PATH=%VCPKG_ROOT%;%PATH%"
+set "PATH=%PATH:c:\opt\vcpkg;c:\opt\vcpkg\installed\x64-windows\bin;=%"
+set "PATH=%VCPKG_ROOT%;%VCPKG_ROOT%\installed\x64-windows\bin;%PATH%"


### PR DESCRIPTION
Some vcpkgs create dlls during their build, which are required for dependent packages. the vcpkg path was not included so the dlls would fail to resolve. 