### PR TITLE
Adding msft_colcon_env.

### DIFF
--- a/msft_colcon_env/CMakeLists.txt
+++ b/msft_colcon_env/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(msft_colcon_env)
+find_package(catkin REQUIRED)
+
+catkin_package()
+
+get_filename_component(PYTHONHOME "${PYTHON_EXECUTABLE}" DIRECTORY)
+file(TO_NATIVE_PATH "${PYTHONHOME}" PYTHONHOME)
+
+# Bootstrap Python Runtime Location
+set(EXTERNAL_PREFIX_CONTENT "")
+set(EXTERNAL_PREFIX_CONTENT "${EXTERNAL_PREFIX_CONTENT}\nset \"PATH=%PATH:${PYTHONHOME}\\Scripts;=%\"")
+set(EXTERNAL_PREFIX_CONTENT "${EXTERNAL_PREFIX_CONTENT}\nset \"PATH=%PATH:${PYTHONHOME};=%\"")
+set(EXTERNAL_PREFIX_CONTENT "${EXTERNAL_PREFIX_CONTENT}\nset \"PATH=${PYTHONHOME};%PATH%\"")
+set(EXTERNAL_PREFIX_CONTENT "${EXTERNAL_PREFIX_CONTENT}\nset \"PATH=${PYTHONHOME}\\Scripts;%PATH%\"")
+set(EXTERNAL_PREFIX_CONTENT "${EXTERNAL_PREFIX_CONTENT}\nset \"PYTHONHOME=${PYTHONHOME}\"")
+
+# Bootstrap CMAKE_PREFIX_PATH
+foreach(_PREFIX $ENV{CMAKE_PREFIX_PATH})
+    file(TO_NATIVE_PATH "${_PREFIX}" NATIVE_PREFIX)
+    file(TO_CMAKE_PATH "${_PREFIX}" CMAKE_PREFIX)
+    set(EXTERNAL_PREFIX_CONTENT "${EXTERNAL_PREFIX_CONTENT}\nset \"PATH=%PATH:${NATIVE_PREFIX}\\bin;=%\"")
+    set(EXTERNAL_PREFIX_CONTENT "${EXTERNAL_PREFIX_CONTENT}\nset \"PATH=${NATIVE_PREFIX}\\bin;%PATH%\"")
+    set(EXTERNAL_PREFIX_CONTENT "${EXTERNAL_PREFIX_CONTENT}\nset \"CMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH:${CMAKE_PREFIX};=%\"")
+    set(EXTERNAL_PREFIX_CONTENT "${EXTERNAL_PREFIX_CONTENT}\nset \"CMAKE_PREFIX_PATH=${CMAKE_PREFIX};%CMAKE_PREFIX_PATH%\"")
+endforeach()
+
+set(
+  hooks
+  "msft_colcon_qt"
+  "msft_colcon_env"
+)
+if(CMAKE_HOST_UNIX)
+  set(shell "sh")
+else()
+  set(shell "bat")
+endif()
+foreach(hook ${hooks})
+  catkin_add_env_hooks("${hook}" SHELLS ${shell} DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/env-hooks)
+endforeach()

--- a/msft_colcon_env/LICENSE
+++ b/msft_colcon_env/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/msft_colcon_env/env-hooks/msft_colcon_env.bat.in
+++ b/msft_colcon_env/env-hooks/msft_colcon_env.bat.in
@@ -1,0 +1,2 @@
+REM generated from msft_ros_env/env-hooks/msft_colcon_env.bat.in
+@EXTERNAL_PREFIX_CONTENT@

--- a/msft_colcon_env/env-hooks/msft_colcon_env.sh.in
+++ b/msft_colcon_env/env-hooks/msft_colcon_env.sh.in
@@ -1,0 +1,1 @@
+REM generated from msft_ros_env/env-hooks/msft_colcon_env.sh.in

--- a/msft_colcon_env/env-hooks/msft_colcon_qt.bat.in
+++ b/msft_colcon_env/env-hooks/msft_colcon_qt.bat.in
@@ -1,0 +1,34 @@
+REM generated from msft_ros_env/env-hooks/msft_colcon_qt.bat.in
+setlocal
+
+set qt5dir=
+for /f "tokens=* USEBACKQ" %%f in (`where qt5core.dll 2^>NUL`) do (
+    set qt5dir=%%f
+    goto :break
+)
+:break
+
+if not defined qt5dir (
+    goto :eof
+)
+
+set basedir=
+CALL :getbasedir %qt5dir%
+
+set abspath=
+CALL :getabspath %basedir%..\plugins
+
+if not exist %abspath% (
+    goto :eof
+)
+
+endlocal && set QT_PLUGIN_PATH=%abspath%
+goto :eof
+
+:getbasedir
+set basedir=%~dp1
+goto :eof
+
+:getabspath
+set abspath=%~f1
+goto :eof

--- a/msft_colcon_env/env-hooks/msft_colcon_qt.sh.in
+++ b/msft_colcon_env/env-hooks/msft_colcon_qt.sh.in
@@ -1,0 +1,1 @@
+REM generated from msft_ros_env/env-hooks/msft_colcon_qt.sh.in

--- a/msft_colcon_env/package.xml
+++ b/msft_colcon_env/package.xml
@@ -1,0 +1,9 @@
+<package>
+  <name>msft_colcon_env</name>
+  <version>0.0.1</version>
+  <description>The package adds the catkin environment prefix in a colcon setting.</description>
+  <maintainer email="seanyen@microsoft.com">Sean Yen</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+</package>


### PR DESCRIPTION
`msft_colcon_env` adds the catkin environment prefix in the `colcon` setting.